### PR TITLE
Feature: Functional logging extensions

### DIFF
--- a/src/Whipstaff.Core/Logging/LogExtensions.cs
+++ b/src/Whipstaff.Core/Logging/LogExtensions.cs
@@ -19,6 +19,9 @@ namespace Whipstaff.Core.Logging
         private static readonly Action<ILogger, string, Exception?> _traceMethodExitAction =
             LoggerMessage.Define<string>(LogLevel.Trace, EventIdFactory.MethodEntryEventId(), "Method Exit: {MethodName}");
 
+        private static readonly Action<ILogger, string, Exception?> _traceMethodExceptionAction =
+            LoggerMessage.Define<string>(LogLevel.Trace, EventIdFactory.MethodEntryEventId(), "Method Exception: {MethodName}");
+
         /// <summary>
         /// Traces the method entry.
         /// </summary>
@@ -64,8 +67,9 @@ namespace Whipstaff.Core.Logging
             this ILogger logger,
             Func<string> messageFunc)
         {
-
+#pragma warning disable CA1062 // Validate arguments of public methods
             logger.LogIfEnabled(LogLevel.Trace, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         /// <summary>
@@ -79,7 +83,9 @@ namespace Whipstaff.Core.Logging
             Exception exception,
             Func<string> messageFunc)
         {
+#pragma warning disable CA1062 // Validate arguments of public methods
             logger.LogIfEnabled(LogLevel.Trace, exception, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         /// <summary>
@@ -91,21 +97,14 @@ namespace Whipstaff.Core.Logging
         public static void TraceMethodException(
             this ILogger logger,
             Exception exception,
-            [CallerMemberName] string callerMemberName = null)
+            [CallerMemberName] string? callerMemberName = null)
         {
-            logger.TraceIfEnabled(exception, () => $"Method Entry: {callerMemberName}");
-        }
+            if (string.IsNullOrWhiteSpace(callerMemberName))
+            {
+                return;
+            }
 
-        /// <summary>
-        /// Traces the method exit.
-        /// </summary>
-        /// <param name="logger">Logging instance.</param>
-        /// <param name="callerMemberName">Name of the method.</param>
-        public static void TraceMethodExit(
-            this ILogger logger,
-            [CallerMemberName] string callerMemberName = null)
-        {
-            logger.TraceIfEnabled(() => $"Method Exit: {callerMemberName}");
+            _traceMethodExceptionAction(logger, callerMemberName, exception);
         }
 
         /// <summary>
@@ -117,7 +116,9 @@ namespace Whipstaff.Core.Logging
             this ILogger logger,
             Func<string> messageFunc)
         {
+#pragma warning disable CA1062 // Validate arguments of public methods
             logger.LogIfEnabled(LogLevel.Warning, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         /// <summary>
@@ -131,7 +132,9 @@ namespace Whipstaff.Core.Logging
             Exception exception,
             Func<string> messageFunc)
         {
+#pragma warning disable CA1062 // Validate arguments of public methods
             logger.LogIfEnabled(LogLevel.Warning, exception, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         /// <summary>
@@ -143,7 +146,25 @@ namespace Whipstaff.Core.Logging
             this ILogger logger,
             Func<string> messageFunc)
         {
+#pragma warning disable CA1062 // Validate arguments of public methods
             logger.LogIfEnabled(LogLevel.Error, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+
+        /// <summary>
+        /// Write a error event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="exception">Exception that occurred.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void ErrorIfEnabled(
+            this ILogger logger,
+            Exception exception,
+            Func<string> messageFunc)
+        {
+#pragma warning disable CA1062 // Validate arguments of public methods
+            logger.LogIfEnabled(LogLevel.Error, exception, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         /// <summary>
@@ -155,7 +176,25 @@ namespace Whipstaff.Core.Logging
             this ILogger logger,
             Func<string> messageFunc)
         {
+#pragma warning disable CA1062 // Validate arguments of public methods
             logger.LogIfEnabled(LogLevel.Information, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+
+        /// <summary>
+        /// Write a information event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="exception">Exception that occurred.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void InformationIfEnabled(
+            this ILogger logger,
+            Exception exception,
+            Func<string> messageFunc)
+        {
+#pragma warning disable CA1062 // Validate arguments of public methods
+            logger.LogIfEnabled(LogLevel.Information, exception, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         /// <summary>
@@ -167,7 +206,25 @@ namespace Whipstaff.Core.Logging
             this ILogger logger,
             Func<string> messageFunc)
         {
+#pragma warning disable CA1062 // Validate arguments of public methods
             logger.LogIfEnabled(LogLevel.Debug, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+
+        /// <summary>
+        /// Write a debug event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="exception">Exception that occurred.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void DebugIfEnabled(
+            this ILogger logger,
+            Exception exception,
+            Func<string> messageFunc)
+        {
+#pragma warning disable CA1062 // Validate arguments of public methods
+            logger.LogIfEnabled(LogLevel.Debug, exception, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         /// <summary>
@@ -179,7 +236,25 @@ namespace Whipstaff.Core.Logging
             this ILogger logger,
             Func<string> messageFunc)
         {
+#pragma warning disable CA1062 // Validate arguments of public methods
             logger.LogIfEnabled(LogLevel.Critical, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+
+        /// <summary>
+        /// Write a critical event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="exception">Exception that occurred.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void CriticalIfEnabled(
+            this ILogger logger,
+            Exception exception,
+            Func<string> messageFunc)
+        {
+#pragma warning disable CA1062 // Validate arguments of public methods
+            logger.LogIfEnabled(LogLevel.Critical, exception, messageFunc);
+#pragma warning restore CA1062 // Validate arguments of public methods
         }
 
         private static void LogIfEnabled(
@@ -194,7 +269,11 @@ namespace Whipstaff.Core.Logging
             }
 
             var message = messageFunc();
+#pragma warning disable CA1848 // Use the LoggerMessage delegates
+#pragma warning disable CA2254 // Template should be a static expression
             logger.Log(logLevel, exception, message);
+#pragma warning restore CA2254 // Template should be a static expression
+#pragma warning restore CA1848 // Use the LoggerMessage delegates
         }
 
         private static void LogIfEnabled(
@@ -208,7 +287,11 @@ namespace Whipstaff.Core.Logging
             }
 
             var message = messageFunc();
+#pragma warning disable CA1848 // Use the LoggerMessage delegates
+#pragma warning disable CA2254 // Template should be a static expression
             logger.Log(logLevel, message);
+#pragma warning restore CA2254 // Template should be a static expression
+#pragma warning restore CA1848 // Use the LoggerMessage delegates
         }
     }
 }

--- a/src/Whipstaff.Core/Logging/LogExtensions.cs
+++ b/src/Whipstaff.Core/Logging/LogExtensions.cs
@@ -54,5 +54,161 @@ namespace Whipstaff.Core.Logging
 
             _traceMethodExitAction(logger, callerMemberName, exception);
         }
+
+        /// <summary>
+        /// Write a trace event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void TraceIfEnabled(
+            this ILogger logger,
+            Func<string> messageFunc)
+        {
+
+            logger.LogIfEnabled(LogLevel.Trace, messageFunc);
+        }
+
+        /// <summary>
+        /// Write a trace event and exception if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="exception">Exception that occurred.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void TraceIfEnabled(
+            this ILogger logger,
+            Exception exception,
+            Func<string> messageFunc)
+        {
+            logger.LogIfEnabled(LogLevel.Trace, exception, messageFunc);
+        }
+
+        /// <summary>
+        /// Traces an exception in a method.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="exception">Exception that occurred.</param>
+        /// <param name="callerMemberName">Name of the method.</param>
+        public static void TraceMethodException(
+            this ILogger logger,
+            Exception exception,
+            [CallerMemberName] string callerMemberName = null)
+        {
+            logger.TraceIfEnabled(exception, () => $"Method Entry: {callerMemberName}");
+        }
+
+        /// <summary>
+        /// Traces the method exit.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="callerMemberName">Name of the method.</param>
+        public static void TraceMethodExit(
+            this ILogger logger,
+            [CallerMemberName] string callerMemberName = null)
+        {
+            logger.TraceIfEnabled(() => $"Method Exit: {callerMemberName}");
+        }
+
+        /// <summary>
+        /// Write a warning event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void WarningIfEnabled(
+            this ILogger logger,
+            Func<string> messageFunc)
+        {
+            logger.LogIfEnabled(LogLevel.Warning, messageFunc);
+        }
+
+        /// <summary>
+        /// Write a warn event and exception if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="exception">Exception that occurred.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void WarningIfEnabled(
+            this ILogger logger,
+            Exception exception,
+            Func<string> messageFunc)
+        {
+            logger.LogIfEnabled(LogLevel.Warning, exception, messageFunc);
+        }
+
+        /// <summary>
+        /// Write a error event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void ErrorIfEnabled(
+            this ILogger logger,
+            Func<string> messageFunc)
+        {
+            logger.LogIfEnabled(LogLevel.Error, messageFunc);
+        }
+
+        /// <summary>
+        /// Write a information event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void InformationIfEnabled(
+            this ILogger logger,
+            Func<string> messageFunc)
+        {
+            logger.LogIfEnabled(LogLevel.Information, messageFunc);
+        }
+
+        /// <summary>
+        /// Write a debug event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void DebugIfEnabled(
+            this ILogger logger,
+            Func<string> messageFunc)
+        {
+            logger.LogIfEnabled(LogLevel.Debug, messageFunc);
+        }
+
+        /// <summary>
+        /// Write a critical event if the log level is enabled.
+        /// </summary>
+        /// <param name="logger">Logging instance.</param>
+        /// <param name="messageFunc">Message producing func to evaluate if log level enabled.</param>
+        public static void CriticalIfEnabled(
+            this ILogger logger,
+            Func<string> messageFunc)
+        {
+            logger.LogIfEnabled(LogLevel.Critical, messageFunc);
+        }
+
+        private static void LogIfEnabled(
+            this ILogger logger,
+            LogLevel logLevel,
+            Exception exception,
+            Func<string> messageFunc)
+        {
+            if (!logger.IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            var message = messageFunc();
+            logger.Log(logLevel, exception, message);
+        }
+
+        private static void LogIfEnabled(
+            this ILogger logger,
+            LogLevel logLevel,
+            Func<string> messageFunc)
+        {
+            if (!logger.IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            var message = messageFunc();
+            logger.Log(logLevel, message);
+        }
     }
 }

--- a/src/Whipstaff.Core/Logging/LogValuesFormatter.cs
+++ b/src/Whipstaff.Core/Logging/LogValuesFormatter.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
@@ -15,6 +16,7 @@ namespace Whipstaff.Core.Logging
     /// <summary>
     /// Formatter to convert the named format items like {NamedformatItem} to <see cref="string.Format(IFormatProvider, string, object)"/> format.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     internal sealed class LogValuesFormatter
     {
         private const string NullValue = "(null)";
@@ -28,7 +30,9 @@ namespace Whipstaff.Core.Logging
 
             OriginalFormat = format;
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
             var vsb = new ValueStringBuilder(stackalloc char[256]);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             int scanIndex = 0;
             int endIndex = format.Length;
 
@@ -55,7 +59,7 @@ namespace Whipstaff.Core.Logging
                     int formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
 
                     vsb.Append(format.AsSpan(scanIndex, openBraceIndex - scanIndex + 1));
-                    vsb.Append(_valueNames.Count.ToString());
+                    vsb.Append(_valueNames.Count.ToString(NumberFormatInfo.InvariantInfo));
                     _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
                     vsb.Append(format.AsSpan(formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1));
 
@@ -124,7 +128,9 @@ namespace Whipstaff.Core.Logging
             return findIndex == -1 ? endIndex : findIndex;
         }
 
+#pragma warning disable SA1202 // Elements should be ordered by access
         public string Format(object?[]? values)
+#pragma warning restore SA1202 // Elements should be ordered by access
         {
             object?[]? formattedValues = values;
 
@@ -145,6 +151,7 @@ namespace Whipstaff.Core.Logging
                         {
                             formattedValues[i] = FormatArgument(values[i]);
                         }
+
                         break;
                     }
 #pragma warning restore SA1515 // Single-line comment should be preceded by blank line
@@ -188,11 +195,15 @@ namespace Whipstaff.Core.Logging
             return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1), FormatArgument(arg2));
         }
 
+#pragma warning disable SA1202 // Elements should be ordered by access
         public KeyValuePair<string, object?> GetValue(object?[] values, int index)
+#pragma warning restore SA1202 // Elements should be ordered by access
         {
             if (index < 0 || index > _valueNames.Count)
             {
+#pragma warning disable CA2201 // Do not raise reserved exception types
                 throw new IndexOutOfRangeException(nameof(index));
+#pragma warning restore CA2201 // Do not raise reserved exception types
             }
 
             if (_valueNames.Count > index)
@@ -231,7 +242,9 @@ namespace Whipstaff.Core.Logging
             // if the value implements IEnumerable, build a comma separated string.
             if (value is IEnumerable enumerable)
             {
+#pragma warning disable CA2000 // Dispose objects before losing scope
                 var vsb = new ValueStringBuilder(stackalloc char[256]);
+#pragma warning restore CA2000 // Dispose objects before losing scope
                 bool first = true;
                 foreach (object? e in enumerable)
                 {
@@ -243,6 +256,7 @@ namespace Whipstaff.Core.Logging
                     vsb.Append(e != null ? e.ToString() : NullValue);
                     first = false;
                 }
+
                 return vsb.ToString();
             }
 

--- a/src/Whipstaff.Core/Logging/LogValuesFormatter.cs
+++ b/src/Whipstaff.Core/Logging/LogValuesFormatter.cs
@@ -1,0 +1,252 @@
+﻿#pragma warning disable SA1636 // File header copyright text should match
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#pragma warning restore SA1636 // File header copyright text should match
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Whipstaff.Core.Logging
+{
+    /// <summary>
+    /// Formatter to convert the named format items like {NamedformatItem} to <see cref="string.Format(IFormatProvider, string, object)"/> format.
+    /// </summary>
+    internal sealed class LogValuesFormatter
+    {
+        private const string NullValue = "(null)";
+        private static readonly char[] FormatDelimiters = { ',', ':' };
+        private readonly string _format;
+        private readonly List<string> _valueNames = new List<string>();
+
+        public LogValuesFormatter(string format)
+        {
+            ThrowHelper.ThrowIfNull(format);
+
+            OriginalFormat = format;
+
+            var vsb = new ValueStringBuilder(stackalloc char[256]);
+            int scanIndex = 0;
+            int endIndex = format.Length;
+
+            while (scanIndex < endIndex)
+            {
+                int openBraceIndex = FindBraceIndex(format, '{', scanIndex, endIndex);
+                if (scanIndex == 0 && openBraceIndex == endIndex)
+                {
+                    // No holes found.
+                    _format = format;
+                    return;
+                }
+
+                int closeBraceIndex = FindBraceIndex(format, '}', openBraceIndex, endIndex);
+
+                if (closeBraceIndex == endIndex)
+                {
+                    vsb.Append(format.AsSpan(scanIndex, endIndex - scanIndex));
+                    scanIndex = endIndex;
+                }
+                else
+                {
+                    // Format item syntax : { index[,alignment][ :formatString] }.
+                    int formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
+
+                    vsb.Append(format.AsSpan(scanIndex, openBraceIndex - scanIndex + 1));
+                    vsb.Append(_valueNames.Count.ToString());
+                    _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
+                    vsb.Append(format.AsSpan(formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1));
+
+                    scanIndex = closeBraceIndex + 1;
+                }
+            }
+
+            _format = vsb.ToString();
+        }
+
+        public string OriginalFormat { get; private set; }
+
+        public List<string> ValueNames => _valueNames;
+
+        private static int FindBraceIndex(string format, char brace, int startIndex, int endIndex)
+        {
+            // Example: {{prefix{{{Argument}}}suffix}}.
+            int braceIndex = endIndex;
+            int scanIndex = startIndex;
+            int braceOccurrenceCount = 0;
+
+            while (scanIndex < endIndex)
+            {
+                if (braceOccurrenceCount > 0 && format[scanIndex] != brace)
+                {
+                    if (braceOccurrenceCount % 2 == 0)
+                    {
+                        // Even number of '{' or '}' found. Proceed search with next occurrence of '{' or '}'.
+                        braceOccurrenceCount = 0;
+                        braceIndex = endIndex;
+                    }
+                    else
+                    {
+                        // An unescaped '{' or '}' found.
+                        break;
+                    }
+                }
+                else if (format[scanIndex] == brace)
+                {
+                    if (brace == '}')
+                    {
+                        if (braceOccurrenceCount == 0)
+                        {
+                            // For '}' pick the first occurrence.
+                            braceIndex = scanIndex;
+                        }
+                    }
+                    else
+                    {
+                        // For '{' pick the last occurrence.
+                        braceIndex = scanIndex;
+                    }
+
+                    braceOccurrenceCount++;
+                }
+
+                scanIndex++;
+            }
+
+            return braceIndex;
+        }
+
+        private static int FindIndexOfAny(string format, char[] chars, int startIndex, int endIndex)
+        {
+            int findIndex = format.IndexOfAny(chars, startIndex, endIndex - startIndex);
+            return findIndex == -1 ? endIndex : findIndex;
+        }
+
+        public string Format(object?[]? values)
+        {
+            object?[]? formattedValues = values;
+
+            if (values != null)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    object formattedValue = FormatArgument(values[i]);
+
+#pragma warning disable SA1515 // Single-line comment should be preceded by blank line
+                              // If the formatted value is changed, we allocate and copy items to a new array to avoid mutating the array passed in to this method
+                    if (!ReferenceEquals(formattedValue, values[i]))
+                    {
+                        formattedValues = new object[values.Length];
+                        Array.Copy(values, formattedValues, i);
+                        formattedValues[i++] = formattedValue;
+                        for (; i < values.Length; i++)
+                        {
+                            formattedValues[i] = FormatArgument(values[i]);
+                        }
+                        break;
+                    }
+#pragma warning restore SA1515 // Single-line comment should be preceded by blank line
+                }
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, _format, formattedValues ?? Array.Empty<object>());
+        }
+
+        // NOTE: This method mutates the items in the array if needed to avoid extra allocations, and should only be used when caller expects this to happen
+        internal string FormatWithOverwrite(object?[]? values)
+        {
+            if (values != null)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    values[i] = FormatArgument(values[i]);
+                }
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, _format, values ?? Array.Empty<object>());
+        }
+
+        internal string Format()
+        {
+            return _format;
+        }
+
+        internal string Format(object? arg0)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0));
+        }
+
+        internal string Format(object? arg0, object? arg1)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1));
+        }
+
+        internal string Format(object? arg0, object? arg1, object? arg2)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1), FormatArgument(arg2));
+        }
+
+        public KeyValuePair<string, object?> GetValue(object?[] values, int index)
+        {
+            if (index < 0 || index > _valueNames.Count)
+            {
+                throw new IndexOutOfRangeException(nameof(index));
+            }
+
+            if (_valueNames.Count > index)
+            {
+                return new KeyValuePair<string, object?>(_valueNames[index], values[index]);
+            }
+
+            return new KeyValuePair<string, object?>("{OriginalFormat}", OriginalFormat);
+        }
+
+        public IEnumerable<KeyValuePair<string, object?>> GetValues(object[] values)
+        {
+            var valueArray = new KeyValuePair<string, object?>[values.Length + 1];
+            for (int index = 0; index != _valueNames.Count; ++index)
+            {
+                valueArray[index] = new KeyValuePair<string, object?>(_valueNames[index], values[index]);
+            }
+
+            valueArray[valueArray.Length - 1] = new KeyValuePair<string, object?>("{OriginalFormat}", OriginalFormat);
+            return valueArray;
+        }
+
+        private object FormatArgument(object? value)
+        {
+            if (value == null)
+            {
+                return NullValue;
+            }
+
+            // since 'string' implements IEnumerable, special case it
+            if (value is string)
+            {
+                return value;
+            }
+
+            // if the value implements IEnumerable, build a comma separated string.
+            if (value is IEnumerable enumerable)
+            {
+                var vsb = new ValueStringBuilder(stackalloc char[256]);
+                bool first = true;
+                foreach (object? e in enumerable)
+                {
+                    if (!first)
+                    {
+                        vsb.Append(", ");
+                    }
+
+                    vsb.Append(e != null ? e.ToString() : NullValue);
+                    first = false;
+                }
+                return vsb.ToString();
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
+++ b/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 
 namespace Whipstaff.Core.Logging
@@ -488,7 +489,7 @@ namespace Whipstaff.Core.Logging
             if (actualCount != expectedNamedParameterCount)
             {
                 throw new ArgumentException(
-                    SR.Format(SR.UnexpectedNumberOfNamedParameters, formatString, expectedNamedParameterCount, actualCount));
+                    SR.Format(CultureInfo.InvariantCulture, "The format string '{0}' does not have the expected number of named parameters. Expected {1} parameter(s) but found {2} parameter(s).", formatString, expectedNamedParameterCount, actualCount));
             }
 
             return logValuesFormatter;

--- a/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
+++ b/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
@@ -72,7 +72,7 @@ namespace Whipstaff.Core.Logging
         /// </summary>
         /// <param name="eventId">The event id to define a log message action for.</param>
         /// <returns>Log Message Action.</returns>
-        public static Action<ILogger, Func<string>, Exception?> GetCriticalBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
+        public static Action<ILogger, Func<string>, Exception?> GetCriticalBasicLoggerMessageActionForEventIdAndFunc(EventId eventId) =>
             GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc(
                 LogLevel.Critical,
                 eventId);

--- a/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
+++ b/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Whipstaff.Core.Logging
@@ -56,8 +58,30 @@ namespace Whipstaff.Core.Logging
         /// </summary>
         /// <param name="eventId">The event id to define a log message action for.</param>
         /// <returns>Log Message Action.</returns>
+        public static Action<ILogger, Func<string>, Exception?> GetCriticalBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+                LogLevel.Critical,
+                eventId);
+
+        /// <summary>
+        /// Gets a basic debug logger message action for an event id. Useful for basic logging of events where there is only
+        /// ever a basic message.
+        /// </summary>
+        /// <param name="eventId">The event id to define a log message action for.</param>
+        /// <returns>Log Message Action.</returns>
         public static Action<ILogger, string, Exception?> GetDebugBasicLoggerMessageActionForEventId(EventId eventId) =>
             GetBasicLoggerMessageActionForLogLevelAndEventId(
+                LogLevel.Debug,
+                eventId);
+
+        /// <summary>
+        /// Gets a basic debug logger message action for an event id. Useful for basic logging of events where there is only
+        /// ever a basic message.
+        /// </summary>
+        /// <param name="eventId">The event id to define a log message action for.</param>
+        /// <returns>Log Message Action.</returns>
+        public static Action<ILogger, Func<string>, Exception?> GetDebugBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
                 LogLevel.Debug,
                 eventId);
 
@@ -69,6 +93,17 @@ namespace Whipstaff.Core.Logging
         /// <returns>Log Message Action.</returns>
         public static Action<ILogger, string, Exception?> GetErrorBasicLoggerMessageActionForEventId(EventId eventId) =>
             GetBasicLoggerMessageActionForLogLevelAndEventId(
+                LogLevel.Error,
+                eventId);
+
+        /// <summary>
+        /// Gets a basic error logger message action for an event id. Useful for basic logging of events where there is only
+        /// ever a basic message.
+        /// </summary>
+        /// <param name="eventId">The event id to define a log message action for.</param>
+        /// <returns>Log Message Action.</returns>
+        public static Action<ILogger, Func<string>, Exception?> GetErrorBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
                 LogLevel.Error,
                 eventId);
 
@@ -89,8 +124,30 @@ namespace Whipstaff.Core.Logging
         /// </summary>
         /// <param name="eventId">The event id to define a log message action for.</param>
         /// <returns>Log Message Action.</returns>
+        public static Action<ILogger, Func<string>, Exception?> GetInformationBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+                LogLevel.Information,
+                eventId);
+
+        /// <summary>
+        /// Gets a basic information logger message action for an event id. Useful for basic logging of events where there is only
+        /// ever a basic message.
+        /// </summary>
+        /// <param name="eventId">The event id to define a log message action for.</param>
+        /// <returns>Log Message Action.</returns>
         public static Action<ILogger, string, Exception?> GetWarningBasicLoggerMessageActionForEventId(EventId eventId) =>
             GetBasicLoggerMessageActionForLogLevelAndEventId(
+                LogLevel.Warning,
+                eventId);
+
+        /// <summary>
+        /// Gets a basic information logger message action for an event id. Useful for basic logging of events where there is only
+        /// ever a basic message.
+        /// </summary>
+        /// <param name="eventId">The event id to define a log message action for.</param>
+        /// <returns>Log Message Action.</returns>
+        public static Action<ILogger, Func<string>, Exception?> GetWarningBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
                 LogLevel.Warning,
                 eventId);
 
@@ -107,5 +164,669 @@ namespace Whipstaff.Core.Logging
                 logLevel,
                 eventId,
                 "{Message}");
+
+        /// <summary>
+        /// Gets a basic log message action where there will only ever be a basic message.
+        /// </summary>
+        /// <param name="logLevel">The logging level.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <returns>Log Message Action.</returns>
+        public static Action<ILogger, Func<string>, Exception?> GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+            LogLevel logLevel,
+            EventId eventId) =>
+            DefineWithFunc<string>(
+                logLevel,
+                eventId,
+                "{Message}");
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Exception?> DefineWithFunc<T1>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineWithFunc<T1>(logLevel, eventId, formatString, options: null);
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Exception?> DefineWithFunc<T1>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        {
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 1);
+
+            void Log(ILogger logger, Func<T1> arg1, Exception? exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1>(formatter, arg1()), exception, LogValues<T1>.Callback);
+            }
+
+            if (options != null && options.SkipEnabledCheck)
+            {
+                return Log;
+            }
+
+            return (logger, arg1, exception) =>
+            {
+                if (logger.IsEnabled(logLevel))
+                {
+                    Log(logger, arg1, exception);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Exception?> DefineWithFunc<T1, T2>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineWithFunc<T1, T2>(logLevel, eventId, formatString, options: null);
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/></param>
+        /// <param name="eventId">The event id</param>
+        /// <param name="formatString">The named format string</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/></param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Exception?> DefineWithFunc<T1, T2>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        {
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 2);
+
+            void Log(ILogger logger, Func<T1> arg1, Func<T2> arg2, Exception? exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1, T2>(formatter, arg1(), arg2()), exception, LogValues<T1, T2>.Callback);
+            }
+
+            if (options != null && options.SkipEnabledCheck)
+            {
+                return Log;
+            }
+
+            return (logger, arg1, arg2, exception) =>
+            {
+                if (logger.IsEnabled(logLevel))
+                {
+                    Log(logger, arg1, arg2, exception);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/></param>
+        /// <param name="eventId">The event id</param>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Exception?> DefineWithFunc<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineWithFunc<T1, T2, T3>(logLevel, eventId, formatString, options: null);
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Exception?> DefineWithFunc<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        {
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 3);
+
+            void Log(ILogger logger, Func<T1> arg1, Func<T2> arg2, Func<T3> arg3, Exception? exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1, T2, T3>(formatter, arg1(), arg2(), arg3()), exception, LogValues<T1, T2, T3>.Callback);
+            }
+
+            if (options != null && options.SkipEnabledCheck)
+            {
+                return Log;
+            }
+
+            return (logger, arg1, arg2, arg3, exception) =>
+            {
+                if (logger.IsEnabled(logLevel))
+                {
+                    Log(logger, arg1, arg2, arg3, exception);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/></param>
+        /// <param name="eventId">The event id</param>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Exception?> DefineWithFunc<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineWithFunc<T1, T2, T3, T4>(logLevel, eventId, formatString, options: null);
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Exception?> DefineWithFunc<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        {
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
+
+            void Log(ILogger logger, Func<T1> arg1, Func<T2> arg2, Func<T3> arg3, Func<T4> arg4, Exception? exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1, T2, T3, T4>(formatter, arg1(), arg2(), arg3(), arg4()), exception, LogValues<T1, T2, T3, T4>.Callback);
+            }
+
+            if (options != null && options.SkipEnabledCheck)
+            {
+                return Log;
+            }
+
+            return (logger, arg1, arg2, arg3, arg4, exception) =>
+            {
+                if (logger.IsEnabled(logLevel))
+                {
+                    Log(logger, arg1, arg2, arg3, arg4, exception);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineWithFunc<T1, T2, T3, T4, T5>(logLevel, eventId, formatString, options: null);
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        {
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 5);
+
+            void Log(ILogger logger, Func<T1> arg1, Func<T2> arg2, Func<T3> arg3, Func<T4> arg4, Func<T5> arg5, Exception? exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1, T2, T3, T4, T5>(formatter, arg1(), arg2(), arg3(), arg4(), arg5()), exception, LogValues<T1, T2, T3, T4, T5>.Callback);
+            }
+
+            if (options != null && options.SkipEnabledCheck)
+            {
+                return Log;
+            }
+
+            return (logger, arg1, arg2, arg3, arg4, arg5, exception) =>
+            {
+                if (logger.IsEnabled(logLevel))
+                {
+                    Log(logger, arg1, arg2, arg3, arg4, arg5, exception);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/></param>
+        /// <param name="eventId">The event id</param>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Func<T6>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineWithFunc<T1, T2, T3, T4, T5, T6>(logLevel, eventId, formatString, options: null);
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/></param>
+        /// <param name="eventId">The event id</param>
+        /// <param name="formatString">The named format string</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/></param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Func<T6>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        {
+            LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 6);
+
+            void Log(ILogger logger, Func<T1> arg1, Func<T2> arg2, Func<T3> arg3, Func<T4> arg4, Func<T5> arg5, Func<T6> arg6, Exception? exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1, T2, T3, T4, T5, T6>(formatter, arg1(), arg2(), arg3(), arg4(), arg5(), arg6()), exception, LogValues<T1, T2, T3, T4, T5, T6>.Callback);
+            }
+
+            if (options != null && options.SkipEnabledCheck)
+            {
+                return Log;
+            }
+
+            return (logger, arg1, arg2, arg3, arg4, arg5, arg6, exception) =>
+            {
+                if (logger.IsEnabled(logLevel))
+                {
+                    Log(logger, arg1, arg2, arg3, arg4, arg5, arg6, exception);
+                }
+            };
+        }
+
+        private static LogValuesFormatter CreateLogValuesFormatter(string formatString, int expectedNamedParameterCount)
+        {
+            var logValuesFormatter = new LogValuesFormatter(formatString);
+
+            int actualCount = logValuesFormatter.ValueNames.Count;
+            if (actualCount != expectedNamedParameterCount)
+            {
+                throw new ArgumentException(
+                    SR.Format(SR.UnexpectedNumberOfNamedParameters, formatString, expectedNamedParameterCount, actualCount));
+            }
+
+            return logValuesFormatter;
+        }
+
+        private readonly struct LogValues<T0> : IReadOnlyList<KeyValuePair<string, object?>>
+        {
+            public static readonly Func<LogValues<T0>, Exception?, string> Callback = (state, exception) => state.ToString();
+
+            private readonly LogValuesFormatter _formatter;
+            private readonly T0 _value0;
+
+            public LogValues(LogValuesFormatter formatter, T0 value0)
+            {
+                _formatter = formatter;
+                _value0 = value0;
+            }
+
+            public KeyValuePair<string, object?> this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
+                    }
+                }
+            }
+
+            public int Count => 2;
+
+            public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+            {
+                for (int i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            public override string ToString() => _formatter.Format(_value0);
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private readonly struct LogValues<T0, T1> : IReadOnlyList<KeyValuePair<string, object?>>
+        {
+            public static readonly Func<LogValues<T0, T1>, Exception?, string> Callback = (state, exception) => state.ToString();
+
+            private readonly LogValuesFormatter _formatter;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+
+            public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1)
+            {
+                _formatter = formatter;
+                _value0 = value0;
+                _value1 = value1;
+            }
+
+            public KeyValuePair<string, object?> this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[1], _value1);
+                        case 2:
+                            return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
+                    }
+                }
+            }
+
+            public int Count => 3;
+
+            public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+            {
+                for (int i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            public override string ToString() => _formatter.Format(_value0, _value1);
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private readonly struct LogValues<T0, T1, T2> : IReadOnlyList<KeyValuePair<string, object?>>
+        {
+            public static readonly Func<LogValues<T0, T1, T2>, Exception?, string> Callback = (state, exception) => state.ToString();
+
+            private readonly LogValuesFormatter _formatter;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+
+            public int Count => 4;
+
+            public KeyValuePair<string, object?> this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[1], _value1);
+                        case 2:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[2], _value2);
+                        case 3:
+                            return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
+                    }
+                }
+            }
+
+            public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2)
+            {
+                _formatter = formatter;
+                _value0 = value0;
+                _value1 = value1;
+                _value2 = value2;
+            }
+
+            public override string ToString() => _formatter.Format(_value0, _value1, _value2);
+
+            public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+            {
+                for (int i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private readonly struct LogValues<T0, T1, T2, T3> : IReadOnlyList<KeyValuePair<string, object?>>
+        {
+            public static readonly Func<LogValues<T0, T1, T2, T3>, Exception?, string> Callback = (state, exception) => state.ToString();
+
+            private readonly LogValuesFormatter _formatter;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+            private readonly T3 _value3;
+
+            public int Count => 5;
+
+            public KeyValuePair<string, object?> this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[1], _value1);
+                        case 2:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[2], _value2);
+                        case 3:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[3], _value3);
+                        case 4:
+                            return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
+                    }
+                }
+            }
+
+            public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3)
+            {
+                _formatter = formatter;
+                _value0 = value0;
+                _value1 = value1;
+                _value2 = value2;
+                _value3 = value3;
+            }
+
+            private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3 };
+
+            public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
+
+            public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+            {
+                for (int i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private readonly struct LogValues<T0, T1, T2, T3, T4> : IReadOnlyList<KeyValuePair<string, object?>>
+        {
+            public static readonly Func<LogValues<T0, T1, T2, T3, T4>, Exception?, string> Callback = (state, exception) => state.ToString();
+
+            private readonly LogValuesFormatter _formatter;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+            private readonly T3 _value3;
+            private readonly T4 _value4;
+
+            public int Count => 6;
+
+            public KeyValuePair<string, object?> this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[1], _value1);
+                        case 2:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[2], _value2);
+                        case 3:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[3], _value3);
+                        case 4:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[4], _value4);
+                        case 5:
+                            return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
+                    }
+                }
+            }
+
+            public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3, T4 value4)
+            {
+                _formatter = formatter;
+                _value0 = value0;
+                _value1 = value1;
+                _value2 = value2;
+                _value3 = value3;
+                _value4 = value4;
+            }
+
+            private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3, _value4 };
+
+            public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
+
+            public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+            {
+                for (int i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private readonly struct LogValues<T0, T1, T2, T3, T4, T5> : IReadOnlyList<KeyValuePair<string, object?>>
+        {
+            public static readonly Func<LogValues<T0, T1, T2, T3, T4, T5>, Exception?, string> Callback = (state, exception) => state.ToString();
+
+            private readonly LogValuesFormatter _formatter;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+            private readonly T3 _value3;
+            private readonly T4 _value4;
+            private readonly T5 _value5;
+
+            public int Count => 7;
+
+            public KeyValuePair<string, object?> this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[1], _value1);
+                        case 2:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[2], _value2);
+                        case 3:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[3], _value3);
+                        case 4:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[4], _value4);
+                        case 5:
+                            return new KeyValuePair<string, object?>(_formatter.ValueNames[5], _value5);
+                        case 6:
+                            return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
+                    }
+                }
+            }
+
+            public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+            {
+                _formatter = formatter;
+                _value0 = value0;
+                _value1 = value1;
+                _value2 = value2;
+                _value3 = value3;
+                _value4 = value4;
+                _value5 = value5;
+            }
+
+            private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3, _value4, _value5 };
+
+            public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
+
+            public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+            {
+                for (int i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
     }
 }

--- a/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
+++ b/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
@@ -73,7 +73,7 @@ namespace Whipstaff.Core.Logging
         /// <param name="eventId">The event id to define a log message action for.</param>
         /// <returns>Log Message Action.</returns>
         public static Action<ILogger, Func<string>, Exception?> GetCriticalBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
-            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+            GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc(
                 LogLevel.Critical,
                 eventId);
 
@@ -94,8 +94,8 @@ namespace Whipstaff.Core.Logging
         /// </summary>
         /// <param name="eventId">The event id to define a log message action for.</param>
         /// <returns>Log Message Action.</returns>
-        public static Action<ILogger, Func<string>, Exception?> GetDebugBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
-            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+        public static Action<ILogger, Func<string>, Exception?> GetDebugBasicLoggerMessageActionForEventIdAndFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc(
                 LogLevel.Debug,
                 eventId);
 
@@ -116,8 +116,8 @@ namespace Whipstaff.Core.Logging
         /// </summary>
         /// <param name="eventId">The event id to define a log message action for.</param>
         /// <returns>Log Message Action.</returns>
-        public static Action<ILogger, Func<string>, Exception?> GetErrorBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
-            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+        public static Action<ILogger, Func<string>, Exception?> GetErrorBasicLoggerMessageActionForEventIdAndFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc(
                 LogLevel.Error,
                 eventId);
 
@@ -138,8 +138,8 @@ namespace Whipstaff.Core.Logging
         /// </summary>
         /// <param name="eventId">The event id to define a log message action for.</param>
         /// <returns>Log Message Action.</returns>
-        public static Action<ILogger, Func<string>, Exception?> GetInformationBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
-            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+        public static Action<ILogger, Func<string>, Exception?> GetInformationBasicLoggerMessageActionForEventIdAndFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc(
                 LogLevel.Information,
                 eventId);
 
@@ -160,8 +160,8 @@ namespace Whipstaff.Core.Logging
         /// </summary>
         /// <param name="eventId">The event id to define a log message action for.</param>
         /// <returns>Log Message Action.</returns>
-        public static Action<ILogger, Func<string>, Exception?> GetWarningBasicLoggerMessageActionForEventIdWithFunc(EventId eventId) =>
-            GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+        public static Action<ILogger, Func<string>, Exception?> GetWarningBasicLoggerMessageActionForEventIdAndFunc(EventId eventId) =>
+            GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc(
                 LogLevel.Warning,
                 eventId);
 
@@ -185,10 +185,10 @@ namespace Whipstaff.Core.Logging
         /// <param name="logLevel">The logging level.</param>
         /// <param name="eventId">The event id.</param>
         /// <returns>Log Message Action.</returns>
-        public static Action<ILogger, Func<string>, Exception?> GetBasicLoggerMessageActionForLogLevelAndEventIdWithFunc(
+        public static Action<ILogger, Func<string>, Exception?> GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc(
             LogLevel logLevel,
             EventId eventId) =>
-            DefineWithFunc<string>(
+            DefineForFunc<string>(
                 logLevel,
                 eventId,
                 "{Message}");
@@ -201,8 +201,8 @@ namespace Whipstaff.Core.Logging
         /// <param name="eventId">The event id.</param>
         /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Exception?> DefineWithFunc<T1>(LogLevel logLevel, EventId eventId, string formatString)
-            => DefineWithFunc<T1>(logLevel, eventId, formatString, options: null);
+        public static Action<ILogger, Func<T1>, Exception?> DefineForFunc<T1>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineForFunc<T1>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
         /// Creates a delegate which can be invoked for logging a message.
@@ -213,7 +213,7 @@ namespace Whipstaff.Core.Logging
         /// <param name="formatString">The named format string.</param>
         /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Exception?> DefineWithFunc<T1>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        public static Action<ILogger, Func<T1>, Exception?> DefineForFunc<T1>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 1);
 
@@ -245,8 +245,8 @@ namespace Whipstaff.Core.Logging
         /// <param name="eventId">The event id.</param>
         /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Exception?> DefineWithFunc<T1, T2>(LogLevel logLevel, EventId eventId, string formatString)
-            => DefineWithFunc<T1, T2>(logLevel, eventId, formatString, options: null);
+        public static Action<ILogger, Func<T1>, Func<T2>, Exception?> DefineForFunc<T1, T2>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineForFunc<T1, T2>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
         /// Creates a delegate which can be invoked for logging a message.
@@ -258,7 +258,7 @@ namespace Whipstaff.Core.Logging
         /// <param name="formatString">The named format string.</param>
         /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Exception?> DefineWithFunc<T1, T2>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        public static Action<ILogger, Func<T1>, Func<T2>, Exception?> DefineForFunc<T1, T2>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 2);
 
@@ -291,8 +291,8 @@ namespace Whipstaff.Core.Logging
         /// <param name="eventId">The event id.</param>
         /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Exception?> DefineWithFunc<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString)
-            => DefineWithFunc<T1, T2, T3>(logLevel, eventId, formatString, options: null);
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Exception?> DefineForFunc<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineForFunc<T1, T2, T3>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
         /// Creates a delegate which can be invoked for logging a message.
@@ -305,7 +305,7 @@ namespace Whipstaff.Core.Logging
         /// <param name="formatString">The named format string.</param>
         /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Exception?> DefineWithFunc<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Exception?> DefineForFunc<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 3);
 
@@ -339,8 +339,8 @@ namespace Whipstaff.Core.Logging
         /// <param name="eventId">The event id.</param>
         /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Exception?> DefineWithFunc<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString)
-            => DefineWithFunc<T1, T2, T3, T4>(logLevel, eventId, formatString, options: null);
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Exception?> DefineForFunc<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineForFunc<T1, T2, T3, T4>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
         /// Creates a delegate which can be invoked for logging a message.
@@ -354,7 +354,7 @@ namespace Whipstaff.Core.Logging
         /// <param name="formatString">The named format string.</param>
         /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Exception?> DefineWithFunc<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Exception?> DefineForFunc<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
 
@@ -389,8 +389,8 @@ namespace Whipstaff.Core.Logging
         /// <param name="eventId">The event id.</param>
         /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString)
-            => DefineWithFunc<T1, T2, T3, T4, T5>(logLevel, eventId, formatString, options: null);
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Exception?> DefineForFunc<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineForFunc<T1, T2, T3, T4, T5>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
         /// Creates a delegate which can be invoked for logging a message.
@@ -405,7 +405,7 @@ namespace Whipstaff.Core.Logging
         /// <param name="formatString">The named format string.</param>
         /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Exception?> DefineForFunc<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 5);
 
@@ -441,8 +441,8 @@ namespace Whipstaff.Core.Logging
         /// <param name="eventId">The event id.</param>
         /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Func<T6>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString)
-            => DefineWithFunc<T1, T2, T3, T4, T5, T6>(logLevel, eventId, formatString, options: null);
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Func<T6>, Exception?> DefineForFunc<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString)
+            => DefineForFunc<T1, T2, T3, T4, T5, T6>(logLevel, eventId, formatString, options: null);
 
         /// <summary>
         /// Creates a delegate which can be invoked for logging a message.
@@ -458,7 +458,7 @@ namespace Whipstaff.Core.Logging
         /// <param name="formatString">The named format string.</param>
         /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
-        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Func<T6>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
+        public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Func<T6>, Exception?> DefineForFunc<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
             LogValuesFormatter formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 6);
 

--- a/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
+++ b/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
@@ -21,7 +21,7 @@ namespace Whipstaff.Core.Logging
     /// <remarks>
     /// This code is based upon https://github.com/dotnet/runtime/blob/e8a85b78f804578729392acd9d6307918c3b23f5/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
     /// which carries the following license.
-    /// 
+    ///
     /// Licensed to the .NET Foundation under one or more agreements.
     /// The .NET Foundation licenses this file to you under the MIT license.
     /// </remarks>
@@ -252,10 +252,10 @@ namespace Whipstaff.Core.Logging
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
         public static Action<ILogger, Func<T1>, Func<T2>, Exception?> DefineWithFunc<T1, T2>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
@@ -286,9 +286,9 @@ namespace Whipstaff.Core.Logging
         /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
         public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Exception?> DefineWithFunc<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString)
             => DefineWithFunc<T1, T2, T3>(logLevel, eventId, formatString, options: null);
@@ -334,9 +334,9 @@ namespace Whipstaff.Core.Logging
         /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
         /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
         public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Exception?> DefineWithFunc<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString)
             => DefineWithFunc<T1, T2, T3, T4>(logLevel, eventId, formatString, options: null);
@@ -436,9 +436,9 @@ namespace Whipstaff.Core.Logging
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
         public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Func<T6>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString)
             => DefineWithFunc<T1, T2, T3, T4, T5, T6>(logLevel, eventId, formatString, options: null);
@@ -452,10 +452,10 @@ namespace Whipstaff.Core.Logging
         /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
-        /// <param name="logLevel">The <see cref="LogLevel"/></param>
-        /// <param name="eventId">The event id</param>
-        /// <param name="formatString">The named format string</param>
-        /// <param name="options">The <see cref="LogDefineOptions"/></param>
+        /// <param name="logLevel">The <see cref="LogLevel"/>.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="formatString">The named format string.</param>
+        /// <param name="options">The <see cref="LogDefineOptions"/>.</param>
         /// <returns>A delegate which when invoked creates a log message.</returns>
         public static Action<ILogger, Func<T1>, Func<T2>, Func<T3>, Func<T4>, Func<T5>, Func<T6>, Exception?> DefineWithFunc<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options)
         {
@@ -518,12 +518,16 @@ namespace Whipstaff.Core.Logging
                         case 1:
                             return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
                         default:
+#pragma warning disable CA2201 // Do not raise reserved exception types
                             throw new IndexOutOfRangeException(nameof(index));
+#pragma warning restore CA2201 // Do not raise reserved exception types
                     }
                 }
             }
 
+#pragma warning disable SA1201 // Elements should appear in the correct order
             public int Count => 2;
+#pragma warning restore SA1201 // Elements should appear in the correct order
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {
@@ -569,12 +573,16 @@ namespace Whipstaff.Core.Logging
                         case 2:
                             return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
                         default:
+#pragma warning disable CA2201 // Do not raise reserved exception types
                             throw new IndexOutOfRangeException(nameof(index));
+#pragma warning restore CA2201 // Do not raise reserved exception types
                     }
                 }
             }
 
+#pragma warning disable SA1201 // Elements should appear in the correct order
             public int Count => 3;
+#pragma warning restore SA1201 // Elements should appear in the correct order
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {
@@ -618,12 +626,16 @@ namespace Whipstaff.Core.Logging
                         case 3:
                             return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
                         default:
+#pragma warning disable CA2201 // Do not raise reserved exception types
                             throw new IndexOutOfRangeException(nameof(index));
+#pragma warning restore CA2201 // Do not raise reserved exception types
                     }
                 }
             }
 
+#pragma warning disable SA1201 // Elements should appear in the correct order
             public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2)
+#pragma warning restore SA1201 // Elements should appear in the correct order
             {
                 _formatter = formatter;
                 _value0 = value0;
@@ -676,12 +688,16 @@ namespace Whipstaff.Core.Logging
                         case 4:
                             return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
                         default:
+#pragma warning disable CA2201 // Do not raise reserved exception types
                             throw new IndexOutOfRangeException(nameof(index));
+#pragma warning restore CA2201 // Do not raise reserved exception types
                     }
                 }
             }
 
+#pragma warning disable SA1201 // Elements should appear in the correct order
             public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3)
+#pragma warning restore SA1201 // Elements should appear in the correct order
             {
                 _formatter = formatter;
                 _value0 = value0;
@@ -692,7 +708,9 @@ namespace Whipstaff.Core.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3 };
 
+#pragma warning disable SA1202 // Elements should be ordered by access
             public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
+#pragma warning restore SA1202 // Elements should be ordered by access
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {
@@ -740,12 +758,16 @@ namespace Whipstaff.Core.Logging
                         case 5:
                             return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
                         default:
+#pragma warning disable CA2201 // Do not raise reserved exception types
                             throw new IndexOutOfRangeException(nameof(index));
+#pragma warning restore CA2201 // Do not raise reserved exception types
                     }
                 }
             }
 
+#pragma warning disable SA1201 // Elements should appear in the correct order
             public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3, T4 value4)
+#pragma warning restore SA1201 // Elements should appear in the correct order
             {
                 _formatter = formatter;
                 _value0 = value0;
@@ -757,7 +779,9 @@ namespace Whipstaff.Core.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3, _value4 };
 
+#pragma warning disable SA1202 // Elements should be ordered by access
             public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
+#pragma warning restore SA1202 // Elements should be ordered by access
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {
@@ -808,12 +832,16 @@ namespace Whipstaff.Core.Logging
                         case 6:
                             return new KeyValuePair<string, object?>("{OriginalFormat}", _formatter.OriginalFormat);
                         default:
+#pragma warning disable CA2201 // Do not raise reserved exception types
                             throw new IndexOutOfRangeException(nameof(index));
+#pragma warning restore CA2201 // Do not raise reserved exception types
                     }
                 }
             }
 
+#pragma warning disable SA1201 // Elements should appear in the correct order
             public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+#pragma warning restore SA1201 // Elements should appear in the correct order
             {
                 _formatter = formatter;
                 _value0 = value0;
@@ -826,7 +854,9 @@ namespace Whipstaff.Core.Logging
 
             private object?[] ToArray() => new object?[] { _value0, _value1, _value2, _value3, _value4, _value5 };
 
+#pragma warning disable SA1202 // Elements should be ordered by access
             public override string ToString() => _formatter.FormatWithOverwrite(ToArray());
+#pragma warning restore SA1202 // Elements should be ordered by access
 
             public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
             {

--- a/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
+++ b/src/Whipstaff.Core/Logging/LoggerMessageFactory.cs
@@ -10,8 +10,21 @@ using Microsoft.Extensions.Logging;
 namespace Whipstaff.Core.Logging
 {
     /// <summary>
-    /// Factory Methods for Logger Messages.
+    /// Factory Methods for Logger Messages. These are aimed at simplifying some use cases for logging.
+    ///
+    /// There are methods that allow passing in functions to the logging so that you can delay the generation \ evaluation
+    /// of any output. This can help with avoiding expensive operations when a log level may not be enabled.
+    ///
+    /// There are also some common log message actions that are used in downstream code, including Roslyn Source generators
+    /// sat in Nucleotide.
     /// </summary>
+    /// <remarks>
+    /// This code is based upon https://github.com/dotnet/runtime/blob/e8a85b78f804578729392acd9d6307918c3b23f5/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
+    /// which carries the following license.
+    /// 
+    /// Licensed to the .NET Foundation under one or more agreements.
+    /// The .NET Foundation licenses this file to you under the MIT license.
+    /// </remarks>
     public static class LoggerMessageFactory
     {
         /// <summary>

--- a/src/Whipstaff.Core/Logging/SR.cs
+++ b/src/Whipstaff.Core/Logging/SR.cs
@@ -1,0 +1,24 @@
+#pragma warning disable SA1636 // File header copyright text should match
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#pragma warning restore SA1636 // File header copyright text should match
+using System.Diagnostics.CodeAnalysis;
+using System.Resources;
+
+namespace System
+{
+    [ExcludeFromCodeCoverage]
+    internal static partial class SR
+    {
+        internal static string Format(IFormatProvider? provider, string resourceFormat, params object?[]? args)
+        {
+            if (args != null)
+            {
+                return string.Format(provider, resourceFormat, args);
+            }
+
+            return resourceFormat;
+        }
+    }
+}

--- a/src/Whipstaff.Core/Logging/ThrowHelper.cs
+++ b/src/Whipstaff.Core/Logging/ThrowHelper.cs
@@ -1,0 +1,59 @@
+#pragma warning disable SA1636 // File header copyright text should match
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#pragma warning restore SA1636 // File header copyright text should match
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+// This file is intended to be used by components that don't have access to ArgumentNullException.ThrowIfNull.
+#pragma warning disable CS0436 // Type conflicts with imported type
+
+namespace System
+{
+    [ExcludeFromCodeCoverage]
+    internal static partial class ThrowHelper
+    {
+        /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
+        /// <param name="argument">The reference type argument to validate as non-null.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        internal static void ThrowIfNull(
+#if NETCOREAPP3_0_OR_GREATER
+            [NotNull]
+#endif
+            object? argument,
+            [CallerArgumentExpression("argument")] string? paramName = null)
+        {
+            if (argument is null)
+            {
+                Throw(paramName);
+            }
+        }
+
+#if NETCOREAPP3_0_OR_GREATER
+        [DoesNotReturn]
+#endif
+        private static void Throw(string? paramName) => throw new ArgumentNullException(paramName);
+    }
+}
+
+#if !NETCOREAPP3_0_OR_GREATER
+#pragma warning disable SA1403 // File may only contain a single namespace
+namespace System.Runtime.CompilerServices
+#pragma warning restore SA1403 // File may only contain a single namespace
+{
+    [ExcludeFromCodeCoverage]
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+#pragma warning disable SA1402 // File may only contain a single type
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}
+#endif

--- a/src/Whipstaff.Core/Logging/ValueStringBuilder.cs
+++ b/src/Whipstaff.Core/Logging/ValueStringBuilder.cs
@@ -1,0 +1,350 @@
+#pragma warning disable SA1636 // File header copyright text should match
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#pragma warning restore SA1636 // File header copyright text should match
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Text
+{
+    [ExcludeFromCodeCoverage]
+    internal ref partial struct ValueStringBuilder
+    {
+        private char[]? _arrayToReturnToPool;
+        private Span<char> _chars;
+        private int _pos;
+
+        public ValueStringBuilder(Span<char> initialBuffer)
+        {
+            _arrayToReturnToPool = null;
+            _chars = initialBuffer;
+            _pos = 0;
+        }
+
+        public ValueStringBuilder(int initialCapacity)
+        {
+            _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            _chars = _arrayToReturnToPool;
+            _pos = 0;
+        }
+
+        public int Length
+        {
+            get => _pos;
+            set
+            {
+#pragma warning disable SA1405 // Debug.Assert should provide message text
+                Debug.Assert(value >= 0);
+#pragma warning restore SA1405 // Debug.Assert should provide message text
+#pragma warning disable SA1405 // Debug.Assert should provide message text
+                Debug.Assert(value <= _chars.Length);
+#pragma warning restore SA1405 // Debug.Assert should provide message text
+                _pos = value;
+            }
+        }
+
+        public int Capacity => _chars.Length;
+
+        public void EnsureCapacity(int capacity)
+        {
+            // This is not expected to be called this with negative capacity
+#pragma warning disable SA1405 // Debug.Assert should provide message text
+            Debug.Assert(capacity >= 0);
+#pragma warning restore SA1405 // Debug.Assert should provide message text
+
+            // If the caller has a bug and calls this with negative capacity, make sure to call Grow to throw an exception.
+            if ((uint)capacity > (uint)_chars.Length)
+#pragma warning disable SA1503 // Braces should not be omitted
+                Grow(capacity - _pos);
+#pragma warning restore SA1503 // Braces should not be omitted
+        }
+
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// Does not ensure there is a null char after <see cref="Length"/>
+        /// This overload is pattern matched in the C# 7.3+ compiler so you can omit
+        /// the explicit method call, and write eg "fixed (char* c = builder)".
+        /// </summary>
+        public ref char GetPinnableReference()
+        {
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/>.</param>
+        public ref char GetPinnableReference(bool terminate)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
+        public ref char this[int index]
+#pragma warning restore SA1201 // Elements should appear in the correct order
+        {
+            get
+            {
+#pragma warning disable SA1405 // Debug.Assert should provide message text
+                Debug.Assert(index < _pos);
+#pragma warning restore SA1405 // Debug.Assert should provide message text
+                return ref _chars[index];
+            }
+        }
+
+        public override string ToString()
+        {
+            string s = _chars.Slice(0, _pos).ToString();
+            Dispose();
+            return s;
+        }
+
+        /// <summary>Returns the underlying storage of the builder.</summary>
+#pragma warning disable SA1201 // Elements should appear in the correct order
+#pragma warning disable SA1623 // Property summary documentation should match accessors
+        public Span<char> RawChars => _chars;
+#pragma warning restore SA1623 // Property summary documentation should match accessors
+#pragma warning restore SA1201 // Elements should appear in the correct order
+
+        /// <summary>
+        /// Returns a span around the contents of the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/>.</param>
+        public ReadOnlySpan<char> AsSpan(bool terminate)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+
+            return _chars.Slice(0, _pos);
+        }
+
+        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+
+        public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+
+        public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+
+        public bool TryCopyTo(Span<char> destination, out int charsWritten)
+        {
+#pragma warning disable RCS1211 // Remove unnecessary 'else'.
+            if (_chars.Slice(0, _pos).TryCopyTo(destination))
+            {
+                charsWritten = _pos;
+                Dispose();
+                return true;
+            }
+            else
+            {
+                charsWritten = 0;
+                Dispose();
+                return false;
+            }
+#pragma warning restore RCS1211 // Remove unnecessary 'else'.
+        }
+
+        public void Insert(int index, char value, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            _chars.Slice(index, count).Fill(value);
+            _pos += count;
+        }
+
+        public void Insert(int index, string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int count = s.Length;
+
+            if (_pos > (_chars.Length - count))
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            s
+#if !NETCOREAPP
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(index));
+            _pos += count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char c)
+        {
+            int pos = _pos;
+            if ((uint)pos < (uint)_chars.Length)
+            {
+                _chars[pos] = c;
+                _pos = pos + 1;
+            }
+            else
+            {
+                GrowAndAppend(c);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int pos = _pos;
+#pragma warning disable SA1108 // Block statements should not contain embedded comments
+            if (s.Length == 1 && (uint)pos < (uint)_chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+            {
+                _chars[pos] = s[0];
+                _pos = pos + 1;
+            }
+            else
+            {
+                AppendSlow(s);
+            }
+#pragma warning restore SA1108 // Block statements should not contain embedded comments
+        }
+
+        private void AppendSlow(string s)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - s.Length)
+            {
+                Grow(s.Length);
+            }
+
+            s
+#if !NETCOREAPP
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(pos));
+            _pos += s.Length;
+        }
+
+#pragma warning disable SA1202 // Elements should be ordered by access
+        public void Append(char c, int count)
+#pragma warning restore SA1202 // Elements should be ordered by access
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, count);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = c;
+            }
+
+            _pos += count;
+        }
+
+        public void Append(ReadOnlySpan<char> value)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - value.Length)
+            {
+                Grow(value.Length);
+            }
+
+            value.CopyTo(_chars.Slice(_pos));
+            _pos += value.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<char> AppendSpan(int length)
+        {
+            int origPos = _pos;
+            if (origPos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            _pos = origPos + length;
+            return _chars.Slice(origPos, length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char c)
+        {
+            Grow(1);
+            Append(c);
+        }
+
+        /// <summary>
+        /// Resize the internal buffer either by doubling current buffer size or
+        /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+        /// <see cref="_pos"/> whichever is greater.
+        /// </summary>
+        /// <param name="additionalCapacityBeyondPos">
+        /// Number of chars requested beyond current position.
+        /// </param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int additionalCapacityBeyondPos)
+        {
+#pragma warning disable SA1405 // Debug.Assert should provide message text
+            Debug.Assert(additionalCapacityBeyondPos > 0);
+#pragma warning restore SA1405 // Debug.Assert should provide message text
+            Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+            const uint ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+            // Increase to at least the required size (_pos + additionalCapacityBeyondPos), but try
+            // to double the size if possible, bounding the doubling to not go beyond the max array length.
+            int newCapacity = (int)Math.Max(
+                (uint)(_pos + additionalCapacityBeyondPos),
+                Math.Min((uint)_chars.Length * 2, ArrayMaxLength));
+
+            // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative.
+            // This could also go negative if the actual required length wraps around.
+            char[] poolArray = ArrayPool<char>.Shared.Rent(newCapacity);
+
+            _chars.Slice(0, _pos).CopyTo(poolArray);
+
+            char[]? toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable SA1202 // Elements should be ordered by access
+        public void Dispose()
+#pragma warning restore SA1202 // Elements should be ordered by access
+        {
+            char[]? toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/src/Whipstaff.UnitTests/Core/Logging/LogExtensionsTest.cs
+++ b/src/Whipstaff.UnitTests/Core/Logging/LogExtensionsTest.cs
@@ -1,0 +1,385 @@
+﻿// Copyright (c) 2022 DHGMS Solutions and Contributors. All rights reserved.
+// This file is licensed to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Whipstaff.Core.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Whipstaff.UnitTests.Core.Logging
+{
+    /// <summary>
+    /// Unit Tests for <see cref="LogExtensions"/>.
+    /// </summary>
+    public static class LogExtensionsTest
+    {
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.TraceMethodEntry"/>.
+        /// </summary>
+        public sealed class TraceMethodEntryMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TraceMethodEntryMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public TraceMethodEntryMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                _logger.TraceMethodEntry();
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.TraceMethodExit"/>.
+        /// </summary>
+        public sealed class TraceMethodExitMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TraceMethodExitMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public TraceMethodExitMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                _logger.TraceMethodExit();
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.TraceIfEnabled(ILogger, Func{string})"/>.
+        /// </summary>
+        public sealed class TraceIfEnabledMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TraceIfEnabledMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public TraceIfEnabledMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                _logger.TraceIfEnabled(() => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.TraceIfEnabled(ILogger, Exception, Func{string})"/>.
+        /// </summary>
+        public sealed class TraceIfEnabledWithExceptionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TraceIfEnabledWithExceptionMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public TraceIfEnabledWithExceptionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                var exception = new InvalidOperationException("Some test exception");
+                _logger.TraceIfEnabled(exception, () => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.TraceIfEnabled(ILogger, Exception, Func{string})"/>.
+        /// </summary>
+        public sealed class TraceMethodExceptionEnabledMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TraceMethodExceptionEnabledMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public TraceMethodExceptionEnabledMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                var exception = new InvalidOperationException("Some test exception");
+                _logger.TraceMethodException(exception);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.WarningIfEnabled(ILogger, Func{string})"/>.
+        /// </summary>
+        public sealed class WarningIfEnabledMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="WarningIfEnabledMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public WarningIfEnabledMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                _logger.WarningIfEnabled(() => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.WarningIfEnabled(ILogger, Exception, Func{string})"/>.
+        /// </summary>
+        public sealed class WarningIfEnabledWithExceptionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="WarningIfEnabledWithExceptionMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public WarningIfEnabledWithExceptionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                var exception = new InvalidOperationException("Some test exception");
+                _logger.WarningIfEnabled(exception, () => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.ErrorIfEnabled(ILogger, Func{string})"/>.
+        /// </summary>
+        public sealed class ErrorIfEnabledMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ErrorIfEnabledMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public ErrorIfEnabledMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                _logger.ErrorIfEnabled(() => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.ErrorIfEnabled(ILogger, Exception, Func{string})"/>.
+        /// </summary>
+        public sealed class ErrorIfEnabledWithExceptionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ErrorIfEnabledWithExceptionMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public ErrorIfEnabledWithExceptionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                var exception = new InvalidOperationException("Some test exception");
+                _logger.ErrorIfEnabled(exception, () => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.InformationIfEnabled(ILogger, Func{string})"/>.
+        /// </summary>
+        public sealed class InformationIfEnabledMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="InformationIfEnabledMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public InformationIfEnabledMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                _logger.InformationIfEnabled(() => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.ErrorIfEnabled(ILogger, Exception, Func{string})"/>.
+        /// </summary>
+        public sealed class InformationIfEnabledWithExceptionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="InformationIfEnabledWithExceptionMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public InformationIfEnabledWithExceptionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                var exception = new InvalidOperationException("Some test exception");
+                _logger.InformationIfEnabled(exception, () => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.DebugIfEnabled(ILogger, Func{string})"/>.
+        /// </summary>
+        public sealed class DebugIfEnabledMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DebugIfEnabledMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DebugIfEnabledMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                _logger.DebugIfEnabled(() => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.ErrorIfEnabled(ILogger, Exception, Func{string})"/>.
+        /// </summary>
+        public sealed class DebugIfEnabledWithExceptionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DebugIfEnabledWithExceptionMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DebugIfEnabledWithExceptionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                var exception = new InvalidOperationException("Some test exception");
+                _logger.DebugIfEnabled(exception, () => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.CriticalIfEnabled(ILogger, Func{string})"/>.
+        /// </summary>
+        public sealed class CriticalIfEnabledMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CriticalIfEnabledMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public CriticalIfEnabledMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                _logger.CriticalIfEnabled(() => "TEST");
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LogExtensions.CriticalIfEnabled(ILogger, Exception, Func{string})"/>.
+        /// </summary>
+        public sealed class CriticalIfEnabledWithExceptionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CriticalIfEnabledWithExceptionMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public CriticalIfEnabledWithExceptionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure the log event occurs.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                var exception = new InvalidOperationException("Some test exception");
+                _logger.CriticalIfEnabled(exception, () => "TEST");
+            }
+        }
+    }
+}

--- a/src/Whipstaff.UnitTests/Core/Logging/LoggerMessageFactoryTests.cs
+++ b/src/Whipstaff.UnitTests/Core/Logging/LoggerMessageFactoryTests.cs
@@ -1,0 +1,450 @@
+﻿// Copyright (c) 2022 DHGMS Solutions and Contributors. All rights reserved.
+// This file is licensed to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+using Whipstaff.Core.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Whipstaff.UnitTests.Core.Logging
+{
+    /// <summary>
+    /// Unit Tests for <see cref="LoggerMessageFactory"/>.
+    /// </summary>
+    public static class LoggerMessageFactoryTests
+    {
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction"/>.
+        /// </summary>
+        public sealed class GetDbContextSaveResultLoggerMessageActionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetDbContextSaveResultLoggerMessageActionMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetDbContextSaveResultLoggerMessageActionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetNoMediatRHandlersRegisteredForTypeLoggerMessageAction"/>.
+        /// </summary>
+        public sealed class GetNoMediatRHandlersRegisteredForTypeLoggerMessageActionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetNoMediatRHandlersRegisteredForTypeLoggerMessageActionMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public GetNoMediatRHandlersRegisteredForTypeLoggerMessageActionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetCountOfMediatRHandlersRegisteredLoggerMessageAction"/>.
+        /// </summary>
+        public sealed class GetCountOfMediatRHandlersRegisteredLoggerMessageActionMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetCountOfMediatRHandlersRegisteredLoggerMessageActionMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetCountOfMediatRHandlersRegisteredLoggerMessageActionMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetCriticalBasicLoggerMessageActionForEventId"/>.
+        /// </summary>
+        public sealed class GetCriticalBasicLoggerMessageActionForEventIdMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetCriticalBasicLoggerMessageActionForEventIdMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetCriticalBasicLoggerMessageActionForEventIdMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetCriticalBasicLoggerMessageActionForEventIdWithFunc"/>.
+        /// </summary>
+        public sealed class GetCriticalBasicLoggerMessageActionForEventIdWithFuncMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetCriticalBasicLoggerMessageActionForEventIdWithFuncMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetCriticalBasicLoggerMessageActionForEventIdWithFuncMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetDebugBasicLoggerMessageActionForEventId"/>.
+        /// </summary>
+        public sealed class GetDebugBasicLoggerMessageActionForEventIdMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetDebugBasicLoggerMessageActionForEventIdMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetDebugBasicLoggerMessageActionForEventIdMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetDebugBasicLoggerMessageActionForEventIdAndFunc"/>.
+        /// </summary>
+        public sealed class GetDebugBasicLoggerMessageActionForEventIdAndFuncMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetDebugBasicLoggerMessageActionForEventIdAndFuncMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetDebugBasicLoggerMessageActionForEventIdAndFuncMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetErrorBasicLoggerMessageActionForEventId"/>.
+        /// </summary>
+        public sealed class GetErrorBasicLoggerMessageActionForEventIdMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetErrorBasicLoggerMessageActionForEventIdMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetErrorBasicLoggerMessageActionForEventIdMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetErrorBasicLoggerMessageActionForEventIdAndFunc"/>.
+        /// </summary>
+        public sealed class GetErrorBasicLoggerMessageActionForEventIdAndFuncMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetErrorBasicLoggerMessageActionForEventIdAndFuncMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetErrorBasicLoggerMessageActionForEventIdAndFuncMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetInformationBasicLoggerMessageActionForEventId"/>.
+        /// </summary>
+        public sealed class GetInformationBasicLoggerMessageActionForEventIdMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetInformationBasicLoggerMessageActionForEventIdMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetInformationBasicLoggerMessageActionForEventIdMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetInformationBasicLoggerMessageActionForEventIdAndFunc"/>.
+        /// </summary>
+        public sealed class GetInformationBasicLoggerMessageActionForEventIdAndFuncMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetInformationBasicLoggerMessageActionForEventIdAndFuncMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetInformationBasicLoggerMessageActionForEventIdAndFuncMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetWarningBasicLoggerMessageActionForEventId"/>.
+        /// </summary>
+        public sealed class GetWarningBasicLoggerMessageActionForEventIdMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetWarningBasicLoggerMessageActionForEventIdMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetWarningBasicLoggerMessageActionForEventIdMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetWarningBasicLoggerMessageActionForEventIdAndFunc"/>.
+        /// </summary>
+        public sealed class GetWarningBasicLoggerMessageActionForEventIdAndFuncMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetWarningBasicLoggerMessageActionForEventIdAndFuncMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetWarningBasicLoggerMessageActionForEventIdAndFuncMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetBasicLoggerMessageActionForLogLevelAndEventId"/>.
+        /// </summary>
+        public sealed class GetBasicLoggerMessageActionForLogLevelAndEventIdMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetBasicLoggerMessageActionForLogLevelAndEventIdMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetBasicLoggerMessageActionForLogLevelAndEventIdMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetBasicLoggerMessageActionForLogLevelAndEventId(LogLevel.Information, new EventId(1, "Event"));
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc"/>.
+        /// </summary>
+        public sealed class GetBasicLoggerMessageActionForLogLevelAndEventIdAndFuncMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetBasicLoggerMessageActionForLogLevelAndEventIdAndFuncMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public GetBasicLoggerMessageActionForLogLevelAndEventIdAndFuncMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.GetBasicLoggerMessageActionForLogLevelAndEventIdAndFunc(LogLevel.Information, new EventId(1, "Event"));
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1}(LogLevel, EventId, string)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT1Method : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT1Method"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT1Method(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.DefineForFunc<int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    "Some Log Message. {Arg}");
+
+                Assert.NotNull(instance);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1}(LogLevel, EventId, string, LogDefineOptions)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT1WithOptionsMethod : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT1WithOptionsMethod"/> class.
+            /// </summary>
+                        /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT1WithOptionsMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = LoggerMessageFactory.DefineForFunc<int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    "Some Log Message. {Arg}",
+                    new LogDefineOptions());
+                Assert.NotNull(instance);
+            }
+        }
+    }
+}

--- a/src/Whipstaff.UnitTests/Core/Logging/LoggerMessageFactoryTests.cs
+++ b/src/Whipstaff.UnitTests/Core/Logging/LoggerMessageFactoryTests.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.Extensions.Logging;
 using Whipstaff.Core.Logging;
 using Xunit;
@@ -14,6 +15,13 @@ namespace Whipstaff.UnitTests.Core.Logging
     /// </summary>
     public static class LoggerMessageFactoryTests
     {
+        private const string FormatString1 = "Some Log Message. {Arg}";
+        private const string FormatString2 = "Some Log Message. {Arg1} {Arg2}";
+        private const string FormatString3 = "Some Log Message. {Arg1} {Arg2} {Arg3}";
+        private const string FormatString4 = "Some Log Message. {Arg1} {Arg2} {Arg3} {Arg4}";
+        private const string FormatString5 = "Some Log Message. {Arg1} {Arg2} {Arg3} {Arg4} {Arg5}";
+        private const string FormatString6 = "Some Log Message. {Arg1} {Arg2} {Arg3} {Arg4} {Arg5} {Arg6}";
+
         /// <summary>
         /// Unit Tests for <see cref="LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction"/>.
         /// </summary>
@@ -109,21 +117,21 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetCriticalBasicLoggerMessageActionForEventId(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
 
         /// <summary>
-        /// Unit Tests for <see cref="LoggerMessageFactory.GetCriticalBasicLoggerMessageActionForEventIdWithFunc"/>.
+        /// Unit Tests for <see cref="LoggerMessageFactory.GetCriticalBasicLoggerMessageActionForEventIdAndFunc"/>.
         /// </summary>
-        public sealed class GetCriticalBasicLoggerMessageActionForEventIdWithFuncMethod : Foundatio.Xunit.TestWithLoggingBase
+        public sealed class GetCriticalBasicLoggerMessageActionForEventIdAndFuncMethod : Foundatio.Xunit.TestWithLoggingBase
         {
             /// <summary>
-            /// Initializes a new instance of the <see cref="GetCriticalBasicLoggerMessageActionForEventIdWithFuncMethod"/> class.
+            /// Initializes a new instance of the <see cref="GetCriticalBasicLoggerMessageActionForEventIdAndFuncMethod"/> class.
             /// </summary>
-                        /// <param name="output">XUnit test output helper instance.</param>
-            public GetCriticalBasicLoggerMessageActionForEventIdWithFuncMethod(ITestOutputHelper output)
+            /// <param name="output">XUnit test output helper instance.</param>
+            public GetCriticalBasicLoggerMessageActionForEventIdAndFuncMethod(ITestOutputHelper output)
                 : base(output)
             {
             }
@@ -134,7 +142,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetCriticalBasicLoggerMessageActionForEventIdAndFunc(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -159,7 +167,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetDebugBasicLoggerMessageActionForEventId(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -184,7 +192,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetCriticalBasicLoggerMessageActionForEventIdAndFunc(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -209,7 +217,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetErrorBasicLoggerMessageActionForEventId(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -234,7 +242,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetErrorBasicLoggerMessageActionForEventIdAndFunc(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -259,7 +267,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetInformationBasicLoggerMessageActionForEventId(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -284,7 +292,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetInformationBasicLoggerMessageActionForEventIdAndFunc(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -309,7 +317,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetWarningBasicLoggerMessageActionForEventId(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -334,7 +342,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             [Fact]
             public void ReturnsLogMessageAction()
             {
-                var instance = LoggerMessageFactory.GetDbContextSaveResultLoggerMessageAction();
+                var instance = LoggerMessageFactory.GetWarningBasicLoggerMessageActionForEventIdAndFunc(new EventId(1, "Event"));
                 Assert.NotNull(instance);
             }
         }
@@ -347,7 +355,7 @@ namespace Whipstaff.UnitTests.Core.Logging
             /// <summary>
             /// Initializes a new instance of the <see cref="GetBasicLoggerMessageActionForLogLevelAndEventIdMethod"/> class.
             /// </summary>
-                        /// <param name="output">XUnit test output helper instance.</param>
+            /// <param name="output">XUnit test output helper instance.</param>
             public GetBasicLoggerMessageActionForLogLevelAndEventIdMethod(ITestOutputHelper output)
                 : base(output)
             {
@@ -390,9 +398,97 @@ namespace Whipstaff.UnitTests.Core.Logging
         }
 
         /// <summary>
+        /// Abstraction of unit tests for logger message define calls.
+        /// </summary>
+        /// <typeparam name="TLogMessageAction">The action signature for the log message action.</typeparam>
+        public abstract class AbstractDefineForFuncMethod<TLogMessageAction> : Foundatio.Xunit.TestWithLoggingBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="AbstractDefineForFuncMethod{TAction}"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            protected AbstractDefineForFuncMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void ReturnsLogMessageAction()
+            {
+                var instance = GetLoggerMessageAction();
+
+                Assert.NotNull(instance);
+            }
+
+            /// <summary>
+            /// Test to ensure a message is logged when the log level allows.
+            /// </summary>
+            [Fact]
+            public void LogsMessage()
+            {
+                var instance = GetLoggerMessageAction();
+
+                var count = Log.LogEntries.Count;
+                var callCount = 0;
+
+                InvokeLogMessageAction(
+                    instance,
+                    () =>
+                    {
+                        callCount++;
+                        return 1;
+                    });
+
+                Assert.True(Log.LogEntries.Count > count);
+                Assert.Equal(1, callCount);
+            }
+
+            /// <summary>
+            /// Test to ensure a log message action instance is created.
+            /// </summary>
+            [Fact]
+            public void SkipsMessage()
+            {
+                var instance = GetLoggerMessageAction();
+
+                Log.MinimumLevel = LogLevel.Error;
+
+                var count = Log.LogEntries.Count;
+                var callCount = 0;
+
+                InvokeLogMessageAction(
+                    instance,
+                    () =>
+                    {
+                        callCount++;
+                        return 1;
+                    });
+
+                Assert.Equal(Log.LogEntries.Count, count);
+                Assert.Equal(0, callCount);
+            }
+
+            /// <summary>
+            /// Logger Message Action to test.
+            /// </summary>
+            /// <returns>Logger Message Action instance.</returns>
+            protected abstract TLogMessageAction GetLoggerMessageAction();
+
+            /// <summary>
+            /// Called to allow the implementing test class to fire off the logger with the correct number of args.
+            /// </summary>
+            /// <param name="instance">Logger Message Action instance.</param>
+            /// <param name="trackingFunc">The func to pass into arg 1 to track execution counts.</param>
+            protected abstract void InvokeLogMessageAction(TLogMessageAction instance, Func<int> trackingFunc);
+        }
+
+        /// <summary>
         /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1}(LogLevel, EventId, string)"/>.
         /// </summary>
-        public sealed class DefineForFuncT1Method : Foundatio.Xunit.TestWithLoggingBase
+        public sealed class DefineForFuncT1Method : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Exception?>>
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="DefineForFuncT1Method"/> class.
@@ -403,25 +499,29 @@ namespace Whipstaff.UnitTests.Core.Logging
             {
             }
 
-            /// <summary>
-            /// Test to ensure a log message action instance is created.
-            /// </summary>
-            [Fact]
-            public void ReturnsLogMessageAction()
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Exception?> GetLoggerMessageAction()
             {
-                var instance = LoggerMessageFactory.DefineForFunc<int>(
+                return LoggerMessageFactory.DefineForFunc<int>(
                     LogLevel.Information,
                     new EventId(1, "Event"),
-                    "Some Log Message. {Arg}");
+                    FormatString1);
+            }
 
-                Assert.NotNull(instance);
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    null);
             }
         }
 
         /// <summary>
         /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1}(LogLevel, EventId, string, LogDefineOptions)"/>.
         /// </summary>
-        public sealed class DefineForFuncT1WithOptionsMethod : Foundatio.Xunit.TestWithLoggingBase
+        public sealed class DefineForFuncT1WithOptionsMethod : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Exception?>>
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="DefineForFuncT1WithOptionsMethod"/> class.
@@ -432,18 +532,388 @@ namespace Whipstaff.UnitTests.Core.Logging
             {
             }
 
-            /// <summary>
-            /// Test to ensure a log message action instance is created.
-            /// </summary>
-            [Fact]
-            public void ReturnsLogMessageAction()
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Exception?> GetLoggerMessageAction()
             {
-                var instance = LoggerMessageFactory.DefineForFunc<int>(
+                return LoggerMessageFactory.DefineForFunc<int>(
                     LogLevel.Information,
                     new EventId(1, "Event"),
-                    "Some Log Message. {Arg}",
+                    FormatString1,
                     new LogDefineOptions());
-                Assert.NotNull(instance);
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2}(LogLevel, EventId, string)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT2Method : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT2Method"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT2Method(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString2);
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2}(LogLevel, EventId, string, LogDefineOptions)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT2WithOptionsMethod : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT2WithOptionsMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT2WithOptionsMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString2,
+                    new LogDefineOptions());
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2, T3}(LogLevel, EventId, string)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT3Method : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT3Method"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT3Method(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString3);
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    () => 3,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2, T3}(LogLevel, EventId, string, LogDefineOptions)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT3WithOptionsMethod : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT3WithOptionsMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT3WithOptionsMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString3,
+                    new LogDefineOptions());
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    () => 3,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2, T3, T4}(LogLevel, EventId, string)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT4Method : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT4Method"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT4Method(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int, int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString4);
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    () => 3,
+                    () => 4,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2, T3, T4}(LogLevel, EventId, string, LogDefineOptions)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT4WithOptionsMethod : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT4WithOptionsMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT4WithOptionsMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int, int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString4,
+                    new LogDefineOptions());
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    () => 3,
+                    () => 4,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2, T3, T4, T5}(LogLevel, EventId, string)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT5Method : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT5Method"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT5Method(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int, int, int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString5);
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    () => 3,
+                    () => 4,
+                    () => 5,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2, T3, T4, T5}(LogLevel, EventId, string, LogDefineOptions)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT5WithOptionsMethod : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT5WithOptionsMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT5WithOptionsMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int, int, int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString5,
+                    new LogDefineOptions());
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    () => 3,
+                    () => 4,
+                    () => 5,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2, T3, T4, T5, T6}(LogLevel, EventId, string)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT6Method : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT6Method"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT6Method(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int, int, int, int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString6);
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    () => 3,
+                    () => 4,
+                    () => 5,
+                    () => 6,
+                    null);
+            }
+        }
+
+        /// <summary>
+        /// Unit Tests for <see cref="LoggerMessageFactory.DefineForFunc{T1, T2, T3, T4, T5, T6}(LogLevel, EventId, string, LogDefineOptions)"/>.
+        /// </summary>
+        public sealed class DefineForFuncT6WithOptionsMethod : AbstractDefineForFuncMethod<Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DefineForFuncT6WithOptionsMethod"/> class.
+            /// </summary>
+            /// <param name="output">XUnit test output helper instance.</param>
+            public DefineForFuncT6WithOptionsMethod(ITestOutputHelper output)
+                : base(output)
+            {
+            }
+
+            /// <inheritdoc/>
+            protected override Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> GetLoggerMessageAction()
+            {
+                return LoggerMessageFactory.DefineForFunc<int, int, int, int, int, int>(
+                    LogLevel.Information,
+                    new EventId(1, "Event"),
+                    FormatString6,
+                    new LogDefineOptions());
+            }
+
+            /// <inheritdoc/>
+            protected override void InvokeLogMessageAction(Action<ILogger, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Func<int>, Exception?> instance, Func<int> trackingFunc)
+            {
+                instance(
+                    _logger,
+                    trackingFunc,
+                    () => 2,
+                    () => 3,
+                    () => 4,
+                    () => 5,
+                    () => 6,
+                    null);
             }
         }
     }


### PR DESCRIPTION
Takes the concept I put in Splat to not evaluate input if a log level isn't enabled and applies it to Microsoft Logging Extensions. This has required taking some of the net core code because it's marked as internal but MIT licensed.