### PR TITLE
use correct framework

### DIFF
--- a/src/Whipstaff.Example.WebApiApp/Dhgms.AspNetCoreContrib.Example.WebApiApp.csproj
+++ b/src/Whipstaff.Example.WebApiApp/Dhgms.AspNetCoreContrib.Example.WebApiApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/src/Whipstaff.Example.WebMvcApp/Dhgms.AspNetCoreContrib.Example.WebMvcApp.csproj
+++ b/src/Whipstaff.Example.WebMvcApp/Dhgms.AspNetCoreContrib.Example.WebMvcApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/src/Whipstaff.IntegrationTests/Whipstaff.IntegrationTests.csproj
+++ b/src/Whipstaff.IntegrationTests/Whipstaff.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Whipstaff.Testing/Whipstaff.Testing.csproj
+++ b/src/Whipstaff.Testing/Whipstaff.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <IsPackable>False</IsPackable>

--- a/src/Whipstaff.UnitTests/Whipstaff.UnitTests.csproj
+++ b/src/Whipstaff.UnitTests/Whipstaff.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp8.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows10.0.19041</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)